### PR TITLE
v1.1 - adding support to User endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v1.1
+
+* added support to User authentication endpoints `login`, `register`, `associate`, `dissociate`, `getUsers`, `changePassword`, `resetPasswordToken`, `removeUser` <!-- I simply forgot this endpoint group exists aswell or it has been added newly. -->
+* added support to Customer endpoint `get_customer_licenses_by_secret`
+
+<!--  additionally removed some unused code and fixed 2 things-->
+
 ## v1.0
 
 * added support to Data endpoints `addDataObject`, `listDataObject`, `incrementIntValue`, `decrementIntValue`, `setStringValue`, `setIntValue`, `removeDataObject`, `uploadValues`

--- a/Cryptolens.php
+++ b/Cryptolens.php
@@ -34,10 +34,10 @@ namespace Cryptolens_PHP_Client {
         public const CRYPTOLENS_LICENSE = "License";
 
         public const CRYPTOLENS_DATA = "Data";
+
+        public const CRYPTOLENS_USER = "User";
         
         private string $token;
-
-        private int $version = 2;
 
         private int $productId;
 
@@ -88,6 +88,7 @@ namespace Cryptolens_PHP_Client {
             require_once dirname(__FILE__) . "/classes/Subscription.cryptolens.php";
             require_once dirname(__FILE__) . "/classes/Customer.cryptolens.php";
             require_once dirname(__FILE__) . "/classes/Analytics.cryptolens.php";
+            require_once dirname(__FILE__) . "/classes/User.cryptolens.php";
             @require_once dirname(__FILE__) . "/classes/License.cryptolens.php";
 
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ In a real values for you can be obtained as follows:
 ### Offline license validation
 
 The API also allows you to validate license files via the `License.cryptolens.php` file.
-To properly configure this function, please convert the XML-styled public key into PEM format (PKC#1) and save it into the `classes/*` directory as `key.pub` (if `License(<Cryptolens $cryptolens>, <string $pathToKey>)` $pathToKey is set, the path is overwritten by specified one).
+To properly configure this function, please convert the XML-styled public key into PEM format (PKC#1) and save it into the `classes/*` directory as `key.pub` (if `License(<Cryptolens $cryptolens>, <string $pathToKey>)` $pathToKey is set, the path is overwritten by specified one). Currently, only "other languages" formatted license files can be processed by this API client.
 
 You can convert your key on a site like this one [here](https://the-x.cn/en-US/certificate/XmlToPem.aspx) or [using this repository](https://github.com/MisterDaneel/PemToXml)
 
@@ -116,59 +116,3 @@ use Cryptolens_PHP_Client\Cryptolens;
 ```
 
 to automatically load the required classes.
-
-
-## Endpoints
-
-* Key
-  * [x] activate
-  * [x] deactivate
-  * [x] create_key
-  * [x] create_trial_key
-  * [x] create_key_from_template
-  * [x] get_key
-  * [x] add_feature
-  * [x] block_key
-  * [x] extend_license
-  * [x] remove_feature
-  * [x] unblock_key
-  * [x] machine_lock_limit
-  * [ ] change_notes\*
-  * [ ] change_reseller\*
-  * [ ] change_customer\*
-  * [ ] Offline Verification
-* Customer
-  * [x] add_customer
-  * [x] edit_customer
-  * [x] remove_customer
-  * [x] get_customer_licenses (does not support the GetCustomerLicensesBySecret Method, yet)
-  * [x] get_customers
-* Data Object
-* Product
-  * [x] get_keys
-  * [x] get_products
-* Auth
-  * [x] key_lock **(Use with caution\*\*)**  
-* Payment Form
-  * [x] create_session
-* Analytics
-  * [x] register_event
-  * [x] register_events
-  * [x] get_events
-  * [x] get_object_log
-  * [x] get_web_api_log
-* Message
-  * [x] get_messages
-  * [x] create_message
-  * [x] remove_message
-* Subscription
-  * [x] record_usage
-* Reseller
-  * [x] add_reseller
-  * [x] edit_reseller
-  * [x] remove_reseller
-  * [x] get_resellers
-  * [x] get_reseller_customers
-
-* = Considered with less priority, therefore this endpoint will not be implemented, yet.
-* ** = This method creates, retrieves or contains sensitive information (e.g. Access Tokens)

--- a/classes/Customer.cryptolens.php
+++ b/classes/Customer.cryptolens.php
@@ -102,6 +102,28 @@ namespace Cryptolens_PHP_Client {
             }
         }
 
+                /**
+         * `get_customer_licenses_by_secret()` - Allows you to retrieve all the customers licenses
+         *
+         * @param integer $secret The secret of the user to retrieve the licenses from
+         * @param bool $detailed If set to true, the license will be returned as a License object, default is just returning the serial key (default: false)
+         * @param bool $metadata If set to false, additional information such as number of activated devices will not be returned (default: true)
+         * @return array|false Either an array containing the licenses or false
+         */
+        public function get_customer_licenses_by_secret(int $secret, bool $detailed = false, bool $metadata = true){
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, array("Secret" => $secret, "Detailed" => $detailed, "Metdata" => $metadata));
+            $c = Helper::connection($parms, "getCustomerLicensesBySecret", $this->group);
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+
         /**
          * `get_customers()` - Allows you to retrieve all customers 
          *

--- a/classes/Endpoints.cryptolens.php
+++ b/classes/Endpoints.cryptolens.php
@@ -39,6 +39,7 @@ namespace Cryptolens_PHP_Client {
             "editCustomer" => "https://api.cryptolens.io/api/customer/EditCustomer",
             "removeCustomer" => "https://api.cryptolens.io/api/customer/RemoveCustomer",
             "getCustomerLicenses" => "https://api.cryptolens.io/api/customer/GetCustomerLicenses",
+            "getCustomerLicensesBySecret" => "https://api.cryptolens.io/api/customer/GetCustomerLicensesBySecret",
             "getCustomers" => "https://api.cryptolens.io/api/customer/GetCustomers",
             # Analytics
             "registerEvent" => "https://api.cryptolens.io/api/ai/RegisterEvent",
@@ -54,7 +55,16 @@ namespace Cryptolens_PHP_Client {
             "setStringValue" => "https://api.cryptolens.io/api/data/SetStringValue",
             "setIntValue" => "https://api.cryptolens.io/api/data/SetIntValue",
             "removeDataObject" => "https://api.cryptolens.io/api/data/RemoveDataObject",
-            "uploadValues" => "https://api.cryptolens.io/api/data/UploadValuesToKey"
+            "uploadValues" => "https://api.cryptolens.io/api/data/UploadValuesToKey",
+            # User
+            "login" => "https://api.cryptolens.io/api/userauth/Login",
+            "register" => "https://api.cryptolens.io/api/userauth/Register",
+            "associate" => "https://api.cryptolens.io/api/userauth/Associate",
+            "dissociate" => "https://api.cryptolens.io/api/userauth/Dissociate",
+            "getUsers" => "https://api.cryptolens.io/api/userauth/GetUsers",
+            "changePassword" => "https://api.cryptolens.io/api/userauth/ChangePassword",
+            "resetPasswordToken" => "https://api.cryptolens.io/api/userauth/ResetPasswordToken",
+            "removeUser" => "https://api.cryptolens.io/api/userauth/RemoveUser"
         ];
 
         public static array $no_response_check = [
@@ -65,6 +75,8 @@ namespace Cryptolens_PHP_Client {
             "getResellers",
             "getResellerCustomers",
             "getCustomerLicenses",
+            "getCustomerLicensesBySecret",
+            "getUsers",
             "getCustomers",
             "getEvents",
             "getWebAPILog",

--- a/classes/Errors.cryptolens.php
+++ b/classes/Errors.cryptolens.php
@@ -9,10 +9,9 @@ namespace Cryptolens_PHP_Client {
      */
     class Errors extends \Exception {
         public function __construct($message, $code = 0, \Exception $previous = null){
-            #$this->error_rep($message);
             parent::__construct($message, $code, $previous);
         }
-        public function __toString(){
+        public function __toString(): string{
             return __CLASS__ . ": [($this->code}]: {$this->message}\n";
         }
 

--- a/classes/Helper.cryptolens.php
+++ b/classes/Helper.cryptolens.php
@@ -32,7 +32,6 @@ namespace Cryptolens_PHP_Client {
                         }
                         $parms[$key] = $value;
                     }
-                    #print_r(var_dump($parms));
                 } else {
                     echo "\$additional_flags is not parsed as an array!";
                 }
@@ -41,7 +40,7 @@ namespace Cryptolens_PHP_Client {
             foreach($parms as $i => $x){
                 if (is_array($x)) {
                     // detect array an skip
-                    continue; // Überspringe die Kodierung für diesen Durchlauf
+                    continue;
                 }
                 if($first) { $first = false; } else { $postfields .= '&';}
 

--- a/classes/License.cryptolens.php
+++ b/classes/License.cryptolens.php
@@ -1,63 +1,114 @@
 <?php
 namespace Cryptolens_PHP_Client {
+    use OpenSSLAsymmetricKey;
 
-    class License {
-        private Cryptolens $cryptolens;
+    class License
+    {
 
         private string $group;
 
+        private string $publicKeyFile;
 
+        private bool $publicKeyIsXMLFormat;
 
-        public function __construct(Cryptolens $cryptolens){
-            $this->cryptolens = $cryptolens;
+        public function __construct(bool $publicKeyIsXMLFormat = false, string $publicKeyFile = null)
+        {
             $this->group = Cryptolens::CRYPTOLENS_LICENSE;
+
+            if ($publicKeyFile != null) {
+                $this->publicKeyFile = $publicKeyFile;
+            } else {
+                $this->publicKeyFile = dirname(__FILE__, 1) . "/key.pub";
+            }
+
+            $this->publicKeyIsXMLFormat = $publicKeyIsXMLFormat;
         }
 
-        public function validateLicense(string $licenseKey, string $signature){
+        /**
+         * `validateLicense()`- Validates a licenseKey against given signature.
+         * @param string $licenseKey The license key
+         * @param string $signature The signature
+         * @return bool True if signature is valid and false otherwise
+         */
+        public function validateLicense(string $licenseKey, string $signature)
+        {
             $licenseKey = base64_decode($licenseKey);
             $signature = base64_decode($signature);
 
-            $verified = openssl_verify($licenseKey, $signature, $this->getPublicKey(), OPENSSL_ALGO_SHA256);
-            if($verified == 1){
+            $verified = openssl_verify($licenseKey, $signature, $this->getPublicKey($this->publicKeyFile, $this->publicKeyIsXMLFormat), OPENSSL_ALGO_SHA256);
+            if ($verified == 1) {
                 return true;
             } else {
                 return false;
-            } 
+            }
         }
 
-        public function validateLicenseFromFileContent(string $fileContent){
+        /**
+         * `validateLicenseFromFileContent` - Validates the licenseKey against signature from given license file content
+         * @param string $fileContent The file content as string
+         * @return bool True if signature is valid and false otherwise
+         */
+        public function validateLicenseFromFileContent(string $fileContent)
+        {
             $fileContent = json_decode($fileContent, true);
             $licenseKey = base64_decode($fileContent["licenseKey"]);
             $signature = base64_decode($fileContent["signature"]);
 
-            $verified = openssl_verify($licenseKey, $signature, $this->getPublicKey(), OPENSSL_ALGO_SHA256);
-            if($verified == 1){
+            $verified = openssl_verify($licenseKey, $signature, $this->getPublicKey($this->publicKeyFile, $this->publicKeyIsXMLFormat), OPENSSL_ALGO_SHA256);
+            if ($verified == 1) {
                 return true;
             } else {
                 return false;
             }
         }
 
-        public function validateLicenseFromFile(string $fileContent){
-            $fileContent = json_decode(file_get_contents($fileContent), true);
+        /**
+         * `validateLicenseFromFile()` - Validates the licenseKey against a signature from given license key file path
+         * @param string $fileContent The file path of the license
+         * @return bool True if signature is valid and false otherwise
+         */
+        public function validateLicenseFromFile(string $fileContent)
+        {
+            $fileContent = $this->readLicenseFile($fileContent);
             $licenseKey = base64_decode($fileContent["licenseKey"]);
             $signature = base64_decode($fileContent["signature"]);
 
-            $verified = openssl_verify($licenseKey, $signature, $this->getPublicKey(), OPENSSL_ALGO_SHA256);
-            if($verified == 1){
+            $verified = openssl_verify($licenseKey, $signature, $this->getPublicKey($this->publicKeyFile, $this->publicKeyIsXMLFormat), OPENSSL_ALGO_SHA256);
+            if ($verified == 1) {
                 return true;
             } else {
                 return false;
             }
         }
 
-        public function getPublicKey(string $pathToKey = null){
-            if($pathToKey == null){
+        /**
+         * `getPublicKey()` - Reads the public key from your specified file or from default ./classes/key.pub
+         * @param string $pathToKey
+         * @return bool|\OpenSSLAsymmetricKey
+         */
+        public function getPublicKey(string $pathToKey = null, bool $xml = false)
+        {
+            if ($pathToKey == null) {
                 $pathToKey = dirname(__FILE__, 1) . "/key.pub";
             }
-            return openssl_pkey_get_public(file_get_contents($pathToKey));
+
+
+            if ($xml == true) {
+                return openssl_pkey_get_public(file_get_contents($pathToKey));
+            } else {
+                return openssl_pkey_get_public(file_get_contents($pathToKey));
+            }
         }
 
+        /**
+         * 
+         * @param string $filePath
+         * @return mixed
+         */
+        public function readLicenseFile(string $filePath)
+        {
+            return json_decode(file_get_contents($filePath), true);
+        }
     }
 }
 

--- a/classes/Results.endpoints.cryptolens.php
+++ b/classes/Results.endpoints.cryptolens.php
@@ -161,7 +161,13 @@ namespace Cryptolens_PHP_Client {
                     "Metadata",
                     "Result",
                     "Message"
-                ]
+                ],
+                "getCustomerLicensesBySecret" => [
+                    "LicenseKeys",
+                    "Metadata",
+                    "Result",
+                    "Message"
+                    ]
                 ],
                 "Data" => [
                     "addDataObject" => [
@@ -190,6 +196,37 @@ namespace Cryptolens_PHP_Client {
                         "Message"
                     ],
                     "uploadValues" => [
+                        "Result",
+                        "Message"
+                    ]
+                ],
+                "User" =>  [
+                    "login" => [
+                        "Result",
+                        "Message"
+                    ],
+                    "register" => [
+                        "Result",
+                        "Message"
+                    ],
+                    "associate" => [
+                        "Result",
+                        "Message"
+                    ],
+                    "dissociate" => [
+                        "Result",
+                        "Message"
+                    ],
+                    "getUsers" => [
+                        "Users",
+                        "Result",
+                        "Message"
+                    ],
+                    "changePassword" => [
+                        "Result",
+                        "Message"
+                    ],
+                    "removeUser" => [
                         "Result",
                         "Message"
                     ]

--- a/classes/User.cryptolens.php
+++ b/classes/User.cryptolens.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace Cryptolens_PHP_Client {
+    class User {
+
+        public Cryptolens $cryptolens;
+
+        public string $group;
+
+        public function __construct(Cryptolens $cryptolens){
+            $this->cryptolens = $cryptolens;
+            $this->group = CRYPTOLENS::CRYPTOLENS_USER;
+        }
+
+        /**
+         * `login()` - Login the user and get all licenses that belong to it.
+         * @param string $username The username
+         * @param string $password The password
+         * @link https://app.cryptolens.io/docs/api/v3/Login
+         * @return array|bool|string
+         */
+        public function login(string $username, string $password){
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, [
+                "Username" => $username,
+                "Password" => $password
+            ]);
+
+            $c = Helper::connection($parms, "login", $this->group);
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+
+        /**
+         * `register()` - Register a new user
+         * @param string $username The username
+         * @param string $password The password
+         * @param string $customerId The customer object ID to associate the user to
+         * @param string $email The email
+         * @link https://app.cryptolens.io/docs/api/v3/Register
+         * @return array|bool|string
+         */
+        public function register(string $username, string $password, string $customerId = null, string $email = null){
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, [
+                "Username" => $username,
+                "Password" => $password,
+                "CustomerId" => $customerId,
+                "Email" => $email
+            ]);
+
+            $c = Helper::connection($parms, "register", $this->group);
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+
+        /**
+         * `associate()` - Associates a user with a customer object.
+         * @param string $username Username to associate customer object with
+         * @param string $customerId The customer object ID to associate to (this value is optional, but what's the point behind calling this function w/ a customer ID?)
+         * @link https://app.cryptolens.io/docs/api/v3/Associate
+         * @return array|bool
+         */
+        public function associate(string $username, string $customerId = null){
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, [
+                "Username" => $username,
+                "CustomerId" => $customerId,
+            ]);
+
+            $c = Helper::connection($parms, "associate", $this->group);
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+
+        /**
+         * `dissociate()` - Dissociates a user from a customer object
+         * @param string $username The username to dissociate the customer object with
+         * @link https://app.cryptolens.io/docs/api/v3/Dissociate
+         * @return array|bool
+         */
+        public function dissociate(string $username){
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, [
+                "Username" => $username
+            ]);
+
+            $c = Helper::connection($parms, "dissociate", $this->group);
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+
+        /**
+         * `getUsers` - Returns a list of all users
+         * @param string $customerId optional customer object ID to get all associates users from
+         * @link https://app.cryptolens.io/docs/api/v3/GetUsers
+         * @return array|bool
+         */
+        public function getUsers(string $customerId = null){
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, [
+                "customerId" => $customerId,
+            ]);
+
+            $c = Helper::connection($parms, "getUsers", $this->group);
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+
+        /**
+         * `changePassword()` - Change the Password of a specific user
+         * @param string $username The username
+         * @param string $newPassword The new password
+         * @param string $oldPassword optional old password if available
+         * @param string $passwordResetToken optional password reset token if available (irrelevant, as the API client requires the token to be set)
+         * @param bool $adminMode optional boolean to specify if user has admin mode enabled
+         * @link https://app.cryptolens.io/docs/api/v3/ChangePassword
+         * @return array|bool
+         */
+        public function changePassword(string $username, string $newPassword, string $oldPassword = null, string $passwordResetToken = null, bool $adminMode = false){
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, [
+                "Username" => $username,
+                "OldPassword" => $oldPassword,
+                "NewPassword" => $newPassword,
+                "PasswordResetToken" => $passwordResetToken,
+                "AdminMode" => $adminMode
+            ]);
+
+            $c = Helper::connection($parms, "changePassword", $this->group);
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+
+        /**
+         * `resetPasswordToken()` - Get the user's password reset token to perform the `changePassword` method on (irrelevant, as the API client requires the token to be set)
+         * @param string $username The username to get the reset token
+         * @link https://app.cryptolens.io/docs/api/v3/ResetPasswordToken
+         * @return array|bool
+         */
+        public function resetPasswordToken(string $username){
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, [
+                "Username" => $username,
+            ]);
+
+            $c = Helper::connection($parms, "resetPasswordToken", $this->group);
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+
+        /**
+         * `removeUser()` - Removes a specified user
+         * @param string $username The username
+         * @link https://app.cryptolens.io/docs/api/v3/RemoveUser
+         * @return array|bool
+         */
+        public function removeUser(string $username){
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, [
+                "Username" => $username,
+            ]);
+
+            $c = Helper::connection($parms, "removeUser", $this->group);
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Manage your licenses with this Cryptolens API client",
     "type": "library",
     "license": "MIT",
-    "version": "1.0",
+    "version": "1.1",
     "authors": [
         {
             "name": "Ente",

--- a/examples/create-key-for-customer.php
+++ b/examples/create-key-for-customer.php
@@ -7,7 +7,7 @@
  * You atleast require to use the base cryptolens, customer and key class.
  */
 
-require "../loader.php";
+require_once "../loader.php";
 
 use Cryptolens_PHP_Client\Cryptolens;
 use Cryptolens_PHP_Client\Customer;

--- a/examples/enable-and-check-feature.php
+++ b/examples/enable-and-check-feature.php
@@ -9,7 +9,7 @@
  */
 
 
-require "../loader.php";
+require_once "../loader.php";
 
 use Cryptolens_PHP_Client\Cryptolens;
 use Cryptolens_PHP_Client\Key;


### PR DESCRIPTION
## v1.1

* added support to User authentication endpoints `login`, `register`, `associate`, `dissociate`, `getUsers`, `changePassword`, `resetPasswordToken`, `removeUser` <!-- I simply forgot this endpoint group exists aswell or it has been added newly. -->
* added support to Customer endpoint `get_customer_licenses_by_secret`

<!--  additionally removed some unused code and fixed 2 things-->