### PR TITLE
New key and licensetemplate endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.4
+
+* changed some paramteter types to the `Key.cryptolens.php` class
+* added `change_notes`, `change_reseller`, `change_customer` and `trial_activation` endpoints to the `Key.cryptolens.php` class
+* added `LicenseTemplate.cryptolens.php` class to support `get_license_templates` endpoint
+
 ## v1.3
 
 * added `customerId` parameter to `Customer::getCustomers()` function to filter customers by their ID.

--- a/Cryptolens.php
+++ b/Cryptolens.php
@@ -12,6 +12,7 @@ namespace Cryptolens_PHP_Client {
     use Cryptolens_PHP_Client\Endpoints;
     use Cryptolens_PHP_Client\Key;
     use Cryptolens_PHP_Client\License;
+    use Cryptolens_PHP_Client\LicenseTemplate;
     use Cryptolens_PHP_Client\Message;
     use Cryptolens_PHP_Client\PaymentForm;
     use Cryptolens_PHP_Client\Reseller;
@@ -58,7 +59,9 @@ namespace Cryptolens_PHP_Client {
         public const CRYPTOLENS_DATA = "Data";
 
         public const CRYPTOLENS_USER = "User";
-        
+
+        public const CRYPTOLENS_LICENSETEMPLATES = "LicenseTemplate";
+
         private string $token;
 
         private int $productId;
@@ -78,6 +81,7 @@ namespace Cryptolens_PHP_Client {
         private $reseller;
         private $subscription;
         private $user;      
+        private $licenseTemplate;
 
     
         /**
@@ -148,7 +152,7 @@ namespace Cryptolens_PHP_Client {
             require_once dirname(__FILE__) . "/classes/Analytics.cryptolens.php";
             require_once dirname(__FILE__) . "/classes/User.cryptolens.php";
             require_once dirname(__FILE__) . "/classes/License.cryptolens.php";
-
+            require_once dirname(__FILE__) . "/classes/LicenseTemplate.cryptolens.php";
 
         }
 
@@ -243,6 +247,11 @@ namespace Cryptolens_PHP_Client {
         public function user(): User {
             if(!$this->user) $this->user = new User($this);
             return $this->user;
+        }
+
+        public function licenseTemplate(): LicenseTemplate {
+            if(!$this->licenseTemplate) $this->licenseTemplate = new LicenseTemplate($this);
+            return $this->licenseTemplate;
         }
 
     }

--- a/README.md
+++ b/README.md
@@ -3,12 +3,19 @@
 This repository contains functions for interacting with the Cryptolens Web API from PHP.
 All endpoints are supported. This API client uses Cryptolens Web API 3.
 
-For more information about the API and possible values and types, visit https://app.cryptolens.io/docs/api/v3, the official API documentation.
+For more information about the API and possible values and types, visit [the official API documentation](https://app.cryptolens.io/docs/api/v3).
 
 To use the library, you can `require_once` the `loader.php` which loads all other classes automatically or use composer where you just have to `require` the composer `autoload.php`. Currently, this library is not safe to use for CLI.
 Inside your script you need to `use` the classes, here is an example:
 
 Needs PHP >7.4.0, works with 8.2
+
+> [!NOTE]
+> This is an independent PHP API client for Cryptolens.
+> The official "client" currently consists of a small procedural script focused on license activation... This package takes a slightly more ambitious approach and provides a structured, object-oriented wrapper around the Cryptolens API.
+>
+> Official client:
+> [https://github.com/Cryptolens/cryptolens-php](https://github.com/Cryptolens/cryptolens-php)
 
 ## Code example
 

--- a/classes/Endpoints.cryptolens.php
+++ b/classes/Endpoints.cryptolens.php
@@ -29,6 +29,10 @@ namespace Cryptolens_PHP_Client {
             "removeFeature" => "https://api.cryptolens.io/api/key/removefeature",
             "unblockKey" => "https://api.cryptolens.io/api/key/unblockkey",
             "machineLockLimit" => "https://api.cryptolens.io/api/key/machinelocklimit",
+            "changeNotes" => "https://api.cryptolens.io/api/key/changenotes",
+            "changeReseller" => "https://api.cryptolens.io/api/key/changereseller",
+            "changeCustomer" => "https://api.cryptolens.io/api/key/changecustomer",
+            "trialActivation" => "https://api.cryptolens.io/api/key/trialactivation",
             # Auth
             "keyLock" => "https://api.cryptolens.io/api/auth/keylock",
             # Products
@@ -78,7 +82,9 @@ namespace Cryptolens_PHP_Client {
             "getUsers" => "https://api.cryptolens.io/api/userauth/GetUsers",
             "changePassword" => "https://api.cryptolens.io/api/userauth/ChangePassword",
             "resetPasswordToken" => "https://api.cryptolens.io/api/userauth/ResetPasswordToken",
-            "removeUser" => "https://api.cryptolens.io/api/userauth/RemoveUser"
+            "removeUser" => "https://api.cryptolens.io/api/userauth/RemoveUser",
+            # License Template
+            "getLicenseTemplates" => "https://api.cryptolens.io/api/licensetemplate/getlicensetemplates"
         ];
 
         /**

--- a/classes/Key.cryptolens.php
+++ b/classes/Key.cryptolens.php
@@ -112,7 +112,7 @@ namespace Cryptolens_PHP_Client {
          * @param string $machineid The machine ID the key is mapped to, you can leave this empty, but sometimes you recieve an error. Read more in the documentation.
          * @link https://api.cryptolens.io/api/key/deactivate
          */
-        public function deactivate(string $key, string $machineid = null){
+        public function deactivate(string $key, string $machineid = ""){
             $parms = $this->build_params($this->cryptolens->getToken(), $this->cryptolens->getProductId(), $key, $machineid);
             $c = $this->connection($parms, "deactivate");
 
@@ -133,7 +133,7 @@ namespace Cryptolens_PHP_Client {
          * @return array|bool Returns an array with the keys "Key", "CustomerId" (only if "NewCustomer" or "AddOrUseExistingCustomer" is set), "Result" and "Message". The key "Key" gets renamed to "Keys" if "NoOfKeys" is greater than 1. On error it returns the Cryptolens response, with the "error" and "response" key
          * @link https://api.cryptolens.io/api/key/createKey
          */
-        public function create_key(array $additional_flags = null){
+        public function create_key(array $additional_flags = []){
             $parms = $this->build_params($this->cryptolens->getToken(), $this->cryptolens->getProductId(), null, null, $additional_flags);
             $c = $this->connection($parms, "createKey");
             if($c == true){
@@ -160,7 +160,7 @@ namespace Cryptolens_PHP_Client {
          * 
          * @param string [optional] Lock the new generated key to a machineId
          */
-        public function create_trial_key(string $machineId = null){
+        public function create_trial_key(string $machineId = ""){
             $parms = $this->build_params($this->cryptolens->getToken(), $this->cryptolens->getProductId(), null, $machineId);
             $c = $this->connection($parms, "createTrialKey");
             if($c == true){
@@ -189,7 +189,7 @@ namespace Cryptolens_PHP_Client {
          * @return array|bool Returns an array with the response or bool on failure
          */
         public function create_key_from_template(int $template){
-            $parms = $this->build_params($this->cryptolens->getToken(), null, null, null, ["LicenseTemplateId" => $template]);
+            $parms = $this->build_params($this->cryptolens->getToken(), "", null, null, ["LicenseTemplateId" => $template]);
             $c = $this->connection($parms, "createKeyFromTemplate");
             if($c == true){
                 if($c["result"] != 0){
@@ -212,7 +212,7 @@ namespace Cryptolens_PHP_Client {
          * @param array $additional_flags Allows you to set more options, like e.g. metadata, fieldstoreturn, floatingtimeinterval and modelversion
          * @return array|bool Returns the key "response" and "licenseKey" (base64 decoded JSON array)
          */
-        public function get_key(string $key, array $additional_flags = null){
+        public function get_key(string $key, array $additional_flags = []){
             $parms = $this->build_params($this->cryptolens->getToken(), $this->cryptolens->getProductId(), $key, null, $additional_flags);
             $c = $this->connection($parms, "getKey");
             if($c == true){
@@ -346,10 +346,81 @@ namespace Cryptolens_PHP_Client {
             }
         }
 
+        public function change_notes(string $key, string $notes){
+            $parms = $this->build_params($this->cryptolens->getToken(), $this->cryptolens->getProductId(), $key, null, ["Notes" => $notes]);
+            if (strlen($notes) > 500) {
+                return Cryptolens::outputHelper([
+                    "error" => "Notes cannot be longer than 500 characters.",
+                    "response" => null
+                ]);
+            }
+            $c = $this->connection($parms, "changeNotes");
+            if($c == true || $this->check_rm($c)){
+                return Cryptolens::outputHelper($c);
+            } else {
+                Cryptolens::outputHelper([
+                    "error" => "An error occurred",
+                    "response" => $c
+                ]);
+            }
+        }
+
+        /**
+         * change_reseller() - Removes or changes the reseller for specified key.
+         * @param string $key The key.
+         * @param int $resellerId The reseller ID, if set to 0 the current reseller will be removed.
+         * @return array|bool
+         */
+        public function change_reseller(string $key, int $resellerId = 0){
+            $parms = $this->build_params($this->cryptolens->getToken(), $this->cryptolens->getProductId(), $key, null, ["ResellerId" => $resellerId]);
+            $c = $this->connection($parms, "changeReseller");
+            if($c == true || $this->check_rm($c)){
+                return Cryptolens::outputHelper($c);
+            } else {
+                Cryptolens::outputHelper([
+                    "error" => "An error occurred",
+                    "response" => $c
+                ]);
+            }
+        }
+
+        /**
+         * change_customer() - Removes or changes the customer for specified key.
+         * @param string $key The key
+         * @param int $customerId The customer ID, if set to 0 the current customer will be removed.
+         * @return array|bool
+         * 
+         */
+        public function change_customer(string $key, int $customerId = 0){
+            $parms = $this->build_params($this->cryptolens->getToken(), $this->cryptolens->getProductId(), $key, null, ["CustomerId" => $customerId]);
+            $c = $this->connection($parms, "changeCustomer");
+            if($c == true || $this->check_rm($c)){
+                return Cryptolens::outputHelper($c);
+            } else {
+                Cryptolens::outputHelper([
+                    "error" => "An error occurred",
+                    "response" => $c
+                ]);
+            }
+        }
+
+        public function trial_activation(string $key, bool $enabled){
+            $parms = $this->build_params($this->cryptolens->getToken(), $this->cryptolens->getProductId(), $key, null, ["Enabled" => (string)$enabled]);
+            $c = $this->connection($parms, "trialActivation");
+            if($c == true || $this->check_rm($c)){
+                return Cryptolens::outputHelper($c);
+            } else {
+                Cryptolens::outputHelper([
+                    "error" => "An error occurred",
+                    "response" => $c
+                ]);
+            }
+        }
+
         /** 
          * build_params() - Internal helper function building the parameters for the cURL request
          */
-        private function build_params($token, $product_id, $key = null, $machineid = null, array $additional_flags = null){
+        private function build_params(string $token, string $product_id, ?string $key = null, ?string $machineid = null, ?array $additional_flags = null){
             $parms = array(
                 "token" => $token,
                 "ProductId" => $product_id,

--- a/classes/LicenseTemplate.cryptolens.php
+++ b/classes/LicenseTemplate.cryptolens.php
@@ -1,0 +1,34 @@
+<?php
+namespace Cryptolens_PHP_Client {
+    /**
+     * License Template
+     * 
+     * Allows the use of all LicenseTemplate endpoints
+     * 
+     * @author Bryan Böhnke-Avan <bryan@openducks.org
+     * @license MIT
+     * @since v1.0
+     * @link https://app.cryptolens.io/docs/api/v3/GetLicenseTemplates
+     */
+    class LicenseTemplate {
+        
+        private Cryptolens $cryptolens;
+
+        private string $group;
+
+        public function __construct(Cryptolens $cryptolens){
+            $this->cryptolens = $cryptolens;
+            $this->group = CRYPTOLENS::CRYPTOLENS_LICENSETEMPLATES;
+        }
+
+        public function get_license_templates(){
+            $params = Helper::build_params($this->cryptolens->getToken(), $this->cryptolens->getProductId());
+            $c = Helper::connection($params, "getLicenseTemplates", $this->group);
+            if($c == true && Helper::check_rm($c)){
+                return Cryptolens::outputHelper($c);
+            } else {
+                return Cryptolens::outputHelper($c, 1);
+            }
+        }
+    }
+}

--- a/classes/Results.endpoints.cryptolens.php
+++ b/classes/Results.endpoints.cryptolens.php
@@ -74,6 +74,23 @@ namespace Cryptolens_PHP_Client {
                     "Result",
                     "Message"
                 ],
+                "changeNotes" => [
+                    "Result",
+                    "Message"
+                ],
+                "changeReseller" => [
+                    "Result",
+                    "Message"
+                ],
+                "changeCustomer" => [
+                    "Result",
+                    "Message"
+                ],
+                "trialActivation" => [
+                    "Result",
+                    "Message",
+                ],
+
             ],
             "Auth" => [
                 "keyLock" => [
@@ -240,6 +257,13 @@ namespace Cryptolens_PHP_Client {
                         "Message"
                     ],
                     "removeUser" => [
+                        "Result",
+                        "Message"
+                    ]
+                ],
+                "LicenseTemplate" => [
+                    "getLicenseTemplates" => [
+                        "LicenseTemplates",
                         "Result",
                         "Message"
                     ]

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Manage your licenses with this Cryptolens API client",
     "type": "library",
     "license": "MIT",
-    "version": "1.3",
+    "version": "1.4",
     "authors": [
         {
             "name": "Bryan Böhnke-Avan",


### PR DESCRIPTION
## v1.4

* changed some paramteter types to the `Key.cryptolens.php` class
* added `change_notes`, `change_reseller`, `change_customer` and `trial_activation` endpoints to the `Key.cryptolens.php` class
* added `LicenseTemplate.cryptolens.php` class to support `get_license_templates` endpoint